### PR TITLE
Allow ffmpeg to be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ slp2mp4/out/Set_A.mp4
 ## Configuration
 For linux, the configuration file is config.json. For Windows, the file is config_windows.json. 
 - 'melee_iso' is the path to your Super Smash Bros. Melee 1.02 ISO. 
-- 'dolphin_dir' and 'ffmpeg' in linux need to be set to the playback path in the installed version of dolphin, and the default installed path of ffmpeg. In windows, these dependencies are downloaded and installed in the local directory so there is no need to change the paths
+- 'dolphin_dir' and 'ffmpeg' in linux need to be set to the playback path in the installed version of dolphin, and the default installed path of ffmpeg. In windows, these dependencies are downloaded and installed in the local directory so there is no need to change the paths; 'ffmpeg' can also be the command name if it's in your PATH
 - 'resolution' can be set to the following. The output resolution is the minimum resolution dolphin can run above the resolution in this configuration.
   - 480p
   - 720p

--- a/slp2mp4/config.py
+++ b/slp2mp4/config.py
@@ -1,4 +1,5 @@
 import os, json, sys
+import shutil
 
 THIS_DIR, _ = os.path.split(os.path.abspath(__file__))
 
@@ -17,7 +18,7 @@ class Config:
             self.check_path(self.melee_iso)
             self.dolphin_dir = os.path.expanduser(j['dolphin_dir'])
             self.check_path(self.dolphin_dir)
-            self.ffmpeg = os.path.expanduser(j['ffmpeg'])
+            self.ffmpeg = os.path.expanduser(shutil.which(j['ffmpeg']))
             self.check_path(self.ffmpeg)
             self.resolution = j['resolution']
             self.widescreen = j['widescreen']


### PR DESCRIPTION
If ffmpeg is already in the PATH, shutil can find it without needing to specify the full path

This allows for you to just have `ffmpeg` in the `config.json` file if it's already in your path.