### PR TITLE
Remove dependency on psutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ The goal is to make it easy to batch-convert replays to HD video without screen 
   - FM-Slippi-r18 playback dolphin can be found here:  
     https://www.smashladder.com/download/dolphin/18/Project+Slippi+%28r18%29
 
-- py-slippi for parsing the slippi file (pip install)  
-  https://github.com/hohav/py-slippi
-
 - psutil for finding number of physical cores (pip install)
   https://github.com/giampaolo/psutil
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The goal is to make it easy to batch-convert replays to HD video without screen 
   - FM-Slippi-r18 playback dolphin can be found here:  
     https://www.smashladder.com/download/dolphin/18/Project+Slippi+%28r18%29
 
-- psutil for finding number of physical cores (pip install)
-  https://github.com/giampaolo/psutil
+- py-slippi for parsing the slippi file (pip install)  
+  https://github.com/hohav/py-slippi
 
 A Super Smash Bros. Melee v1.02 NTSC ISO.
 

--- a/slp2mp4/slp-to-mp4.py
+++ b/slp2mp4/slp-to-mp4.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sys, json, subprocess, time, shutil, uuid, multiprocessing, psutil, glob
+import os, sys, json, subprocess, time, shutil, uuid, multiprocessing, glob
 from pathlib import Path
 from slippi import Game
 from config import Config
@@ -50,7 +50,7 @@ def is_game_too_short(num_frames, remove_short):
 
 def get_num_processes(conf):
     if conf.parallel_games == "recommended":
-        return psutil.cpu_count(logical=False)
+        return multiprocessing.cpu_count()
     else:
         return int(conf.parallel_games)
 


### PR DESCRIPTION
On Windows, `psutil` requires installing Microsoft C++ Build Tools which is a multi-gig dependency. Instead, we can get the number of CPU's with `multiprocessing`