### PR TITLE
Update `DOLPHIN_NAME` for Windows

### DIFF
--- a/slp2mp4/config.py
+++ b/slp2mp4/config.py
@@ -5,7 +5,7 @@ THIS_DIR, _ = os.path.split(os.path.abspath(__file__))
 
 if sys.platform == "win32":
     THIS_CONFIG = os.path.join(THIS_DIR, 'config_windows.json')
-    DOLPHIN_NAME = 'Dolphin.exe'
+    DOLPHIN_NAME = 'Slippi Dolphin.exe'
 else:
     THIS_CONFIG = os.path.join(THIS_DIR, 'config.json')
     DOLPHIN_NAME = 'dolphin-emu'


### PR DESCRIPTION
In the latest Slippi, the playback Dolphin has a different name